### PR TITLE
remove unsigned

### DIFF
--- a/src/Resources/contao/dca/tl_form_field.php
+++ b/src/Resources/contao/dca/tl_form_field.php
@@ -4,13 +4,13 @@ $GLOBALS['TL_DCA']['tl_form_field']['fields'] += [
     'recaptch3_threshold' => [
         'label'             => &$GLOBALS['TL_LANG']['tl_form_field']['recaptcha3_threshold'],
         'inputType'         => 'text',
-        'sql'               => "varchar(8) unsigned NOT NULL default ''",
+        'sql'               => "varchar(8) NOT NULL default ''",
         'eval'              => ['tl_class' => 'w50 clr'],
     ],
     'recaptcha3_action' => [
         'label'             => &$GLOBALS['TL_LANG']['tl_form_field']['recaptcha3_action'],
         'inputType'         => 'text',
-        'sql'               => "varchar(120) unsigned NOT NULL default ''",
+        'sql'               => "varchar(120) NOT NULL default ''",
         'eval'              => ['tl_class' => 'w50', 'rgxp' => 'recaptcha']
     ],
 ];


### PR DESCRIPTION
which does not make sense with a `VARCHAR`.

See also https://community.contao.org/de/showthread.php?75077-Datenbankfelder-werden-bei-dieschittigs-contao-recaptcha-nicht-angelegt where I suspect this as cause