### PR TITLE
Support for contao TL_LANGUAGE

### DIFF
--- a/src/Resources/contao/templates/form_recaptcha.html5
+++ b/src/Resources/contao/templates/form_recaptcha.html5
@@ -9,6 +9,7 @@
         id="recaptcha-<?= $this->strCaptchaKey ?>"
         data-sitekey="<?= $this->publicKey ?>"
         data-callback="onSubmit_<?= $this->strCaptchaKey ?>"
+        data-hl="<?= $GLOBALS['TL_LANGUAGE'] ?>"
         <?php if ($this->recaptchaType == 'invisible'): ?> data-size="invisible" <?php endif; ?>
     ></div>
 

--- a/src/Resources/contao/templates/form_recaptcha.html5
+++ b/src/Resources/contao/templates/form_recaptcha.html5
@@ -9,11 +9,10 @@
         id="recaptcha-<?= $this->strCaptchaKey ?>"
         data-sitekey="<?= $this->publicKey ?>"
         data-callback="onSubmit_<?= $this->strCaptchaKey ?>"
-        data-hl="<?= $GLOBALS['TL_LANGUAGE'] ?>"
         <?php if ($this->recaptchaType == 'invisible'): ?> data-size="invisible" <?php endif; ?>
     ></div>
 
-    <script src="https://www.google.com/recaptcha/api.js?onload=onRecaptchaLoadCallbackField<?= $this->strCaptchaKey ?><?php if ($this->recaptchaType == 'recaptcha3'): ?>&render=<?= $this->publicKey ?><?php endif; ?>" defer async></script>
+    <script src="https://www.google.com/recaptcha/api.js?onload=onRecaptchaLoadCallbackField<?= $this->strCaptchaKey ?>&hl=<?= $GLOBALS['TL_LANGUAGE'] ?><?php if ($this->recaptchaType == 'recaptcha3'): ?>&render=<?= $this->publicKey ?><?php endif; ?>" defer async></script>
     <script type="text/javascript" defer async>
         function onRecaptchaLoadCallbackField<?= $this->strCaptchaKey ?> () {
             window.onSubmit_<?= $this->strCaptchaKey ?> = function () { };


### PR DESCRIPTION
Inspiration on how to easily localize the ReCaptcha with Contao's currently selected language. 
I'm not a Contao expert so I don't know about the availability of TL_LANGUAGE throughout the different Contao versions (can it be `null` oder does it default to `"de"`?).
This template can also easily be overridden in the Contao _Templates_ section but maybe you'd want to add this to the core plugin.

https://developers.google.com/recaptcha/docs/language
